### PR TITLE
Add reaction time measurement and false-start handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,12 +5,14 @@ const clickArea = document.getElementById('click-area');
 
 let canClick = false;
 let waitTimerId = null;
+let clickStartTime = 0; // Timestamp for when "CLICK!" appears.
 
 // Start button sets up the "wait" phase.
 startBtn.addEventListener('click', () => {
   statusText.textContent = 'WAIT...';
   startBtn.disabled = true;
   canClick = false;
+  clickStartTime = 0;
 
   // Wait for a random amount of time before showing "CLICK!".
   const randomDelay = Math.floor(Math.random() * 3000) + 1000; // 1-4 seconds
@@ -18,20 +20,40 @@ startBtn.addEventListener('click', () => {
   waitTimerId = setTimeout(() => {
     statusText.textContent = 'CLICK!';
     canClick = true;
+
+    // Save the exact moment the player is allowed to click.
+    clickStartTime = Date.now();
   }, randomDelay);
 });
 
-// Clicking the large area only works when "CLICK!" is shown.
+// Clicking the large area handles both false starts and valid clicks.
 clickArea.addEventListener('click', () => {
+  // If player clicked before "CLICK!", it's a false start.
   if (!canClick) {
+    // Only treat it as a false start while we are actively waiting.
+    if (startBtn.disabled) {
+      statusText.textContent = 'FALSE START!';
+      startBtn.disabled = false;
+
+      // Cancel the pending timer because the round is over.
+      if (waitTimerId) {
+        clearTimeout(waitTimerId);
+        waitTimerId = null;
+      }
+    }
+
     return;
   }
 
-  statusText.textContent = 'Click Start';
+  // Player clicked at the correct time, so calculate reaction time.
+  const reactionTime = Date.now() - clickStartTime;
+  statusText.textContent = `Reaction time: ${reactionTime} ms`;
+
+  // Reset for the next round.
   canClick = false;
   startBtn.disabled = false;
+  clickStartTime = 0;
 
-  // Clear the timer just in case a new round starts quickly.
   if (waitTimerId) {
     clearTimeout(waitTimerId);
     waitTimerId = null;


### PR DESCRIPTION
### Motivation
- Add a simple reaction-time feature so the game reports how quickly the player responds when the screen changes to `CLICK!`.
- Provide explicit false-start feedback when the player clicks during `WAIT...` to make the game behavior clearer for beginners.
- Keep the implementation simple and well-commented so it is easy to read and extend.

### Description
- Updated `script.js` to add a `clickStartTime` variable to hold the timestamp when the UI changes to `CLICK!`.
- Record the allowed-click timestamp with `clickStartTime = Date.now()` when the `WAIT...` timer fires and the status changes to `CLICK!`.
- Compute elapsed time on a valid click using `Date.now() - clickStartTime` and display it as `Reaction time: ___ ms` in the status text.
- Detect clicks during the `WAIT...` phase and display `FALSE START!`, cancel the pending timer, and re-enable the Start button.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62f29f5e88328ae8c11b44eac0299)