### PR TITLE
Improve click area visual feedback by game state

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,6 +7,18 @@ let canClick = false;
 let waitTimerId = null;
 let clickStartTime = 0; // Timestamp for when "CLICK!" appears.
 
+// List of all possible visual state classes for the click area.
+const areaStates = ['state-neutral', 'state-waiting', 'state-ready', 'state-warning'];
+
+// Small helper: keep state updates in one place so the code stays easy to read.
+function setClickAreaState(stateClass) {
+  clickArea.classList.remove(...areaStates);
+  clickArea.classList.add(stateClass);
+}
+
+// Initial state when the page first loads.
+setClickAreaState('state-neutral');
+
 // Start button sets up the "wait" phase.
 startBtn.addEventListener('click', () => {
   statusText.textContent = 'WAIT...';
@@ -14,12 +26,18 @@ startBtn.addEventListener('click', () => {
   canClick = false;
   clickStartTime = 0;
 
+  // During waiting, the area should show a warning/red appearance.
+  setClickAreaState('state-waiting');
+
   // Wait for a random amount of time before showing "CLICK!".
   const randomDelay = Math.floor(Math.random() * 3000) + 1000; // 1-4 seconds
 
   waitTimerId = setTimeout(() => {
     statusText.textContent = 'CLICK!';
     canClick = true;
+
+    // Green means the player can click now.
+    setClickAreaState('state-ready');
 
     // Save the exact moment the player is allowed to click.
     clickStartTime = Date.now();
@@ -34,6 +52,9 @@ clickArea.addEventListener('click', () => {
     if (startBtn.disabled) {
       statusText.textContent = 'FALSE START!';
       startBtn.disabled = false;
+
+      // Show warning feedback for false start.
+      setClickAreaState('state-warning');
 
       // Cancel the pending timer because the round is over.
       if (waitTimerId) {
@@ -53,6 +74,9 @@ clickArea.addEventListener('click', () => {
   canClick = false;
   startBtn.disabled = false;
   clickStartTime = 0;
+
+  // After a valid reaction result, go back to neutral appearance.
+  setClickAreaState('state-neutral');
 
   if (waitTimerId) {
     clearTimeout(waitTimerId);

--- a/style.css
+++ b/style.css
@@ -47,4 +47,29 @@ body {
   border-radius: 10px;
   border: 3px dashed #9aa3b2;
   background: #eef2f8;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+/* Neutral state: used while idle and after a valid result. */
+#click-area.state-neutral {
+  border-color: #9aa3b2;
+  background: #eef2f8;
+}
+
+/* Waiting state: show a warning tone while player must not click yet. */
+#click-area.state-waiting {
+  border-color: #d32f2f;
+  background: #fde8e8;
+}
+
+/* Ready state: green means it is safe to click now. */
+#click-area.state-ready {
+  border-color: #2e7d32;
+  background: #e8f5e9;
+}
+
+/* Warning state: used for a false start message. */
+#click-area.state-warning {
+  border-color: #b71c1c;
+  background: #ffcdd2;
 }


### PR DESCRIPTION
### Motivation
- Make the large reaction click area provide clear, beginner-friendly visual cues that reflect the game's state so players immediately understand when to wait, click, or that they false-started.
- Use simple, commented code so the behavior is easy to follow and maintain for new contributors.

### Description
- Added CSS state classes and transitions in `style.css` for `state-neutral`, `state-waiting`, `state-ready`, and `state-warning` to change border and background colors for the click area.
- Added a small `areaStates` list and a `setClickAreaState` helper in `script.js` to centralize visual updates and keep the logic simple and readable.
- Updated game flow in `script.js` to set `state-waiting` when a round starts, `state-ready` when the player may click, `state-warning` on a false start, and `state-neutral` after a valid reaction result, with inline comments explaining each step.

### Testing
- Ran automated file inspections to verify `style.css` and `script.js` were updated and contain the new classes and helper function, and these checks succeeded.
- Executed commands to print and review the modified file contents and confirmed the expected state transitions are present, with no errors reported by the inspection steps.
- No automated runtime test suite exists in the project, so no unit/integration tests were run against application behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6305c3c5c8328b0bccbc58869e1ff)